### PR TITLE
Add User Registration with Inline Validation and Live User Search Usi…

### DIFF
--- a/views/partials/flashmessages_partial.templ
+++ b/views/partials/flashmessages_partial.templ
@@ -3,35 +3,46 @@ package partials
 import "github.com/gofiber/fiber/v2"
 
 templ FlashMessages(msg fiber.Map) {
-	if msg["message"] != nil {
+	msgType, _ := msg["type"].(string)
+	message, hasMessage := msg["message"].(string)
+
+	if hasMessage {
+		isError := msgType == "error"
 		<div
- 			role="alert"
- 			class={ "alert w-fit min-w-[384px] mx-auto mt-12", templ.KV("alert-success", msg["type"] == "success"),
-                templ.KV("alert-error", msg["type"] == "error") }
-		>
-			if msg["type"] == "error" {
-				<svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
-					<path
- 						stroke-linecap="round"
- 						stroke-linejoin="round"
- 						stroke-width="2"
- 						d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
-					></path>
-				</svg>
-			} else {
-				<svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
-					<path
- 						stroke-linecap="round"
- 						stroke-linejoin="round"
- 						stroke-width="2"
- 						d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-					></path>
-				</svg>
+			role="alert"
+			class={ 
+				"alert w-fit min-w-[384px] mx-auto mt-12", 
+				templ.KV("alert-success", !isError), 
+				templ.KV("alert-error", isError) 
 			}
-			<span>{ msg["message"].(string) }</span>
+		>
+			{ renderIcon(isError) }
+			<span>{ message }</span>
 			<button class="text-3xl font-black" _="on click remove the closest <div/>">
 				×
 			</button>
 		</div>
+	}
+}
+
+templ renderIcon(isError bool) {
+	if isError {
+		<svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
+			<path
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="2"
+				d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
+			></path>
+		</svg>
+	} else {
+		<svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
+			<path
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="2"
+				d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+			></path>
+		</svg>
 	}
 }


### PR DESCRIPTION
1. User Registration Page with HTMX Partial Updates
Jira: [GTH-3](https://secure-easily-ox.atlassian.net/browse/GTH-3)

Added a new user registration page to the gofiber-templ-htmx app.
Built the form UI using [[Templ](https://templ.guide/)](https://templ.guide/) components.
Integrated HTMX for inline error validation, enabling partial updates without full page reloads.
Server responds with partial HTML for dynamic field-level error feedback.
2. Live Search on /users Page
Jira: [GTH-4](https://secure-easily-ox.atlassian.net/browse/GTH-4)

Introduced a live search feature on the /users page.
As users type in the search field, results are dynamically updated using HTMX requests.
Search results are rendered server-side with Templ and returned as partial responses via GoFiber.
Enhanced UX by avoiding full page reloads during filtering.